### PR TITLE
Update core.clj

### DIFF
--- a/src/manifest/core.clj
+++ b/src/manifest/core.clj
@@ -25,5 +25,4 @@
            "!/META-INF/MANIFEST.MF")))
 
     (catch Exception _
-      (println "Warning could not find a manifest file on the classpath")
       {})))


### PR DESCRIPTION
Prevent annoying println to appear every time an attempt is made to read the manifest from the class path. Consider logging instead.
