### PR TITLE
Continuations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ pom.xml.asc
 \#*\#
 .\#*
 .DS_Store
+.lein-env
+.nrepl-port

--- a/dev-resources/MANIFEST.MF
+++ b/dev-resources/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Release-Version: 1.1.0-long-version-name
+ -first-continuation
+ -second-continuation
+Build-Timestamp: 2016-09-20 16:42:23+0000
+Built-By: A Clojure
+  Developer
+Created-By: Leiningen 2.6.1
+Build-Jdk: 1.8.0_92
+Main-Class: clj_simple.app

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,7 @@
-(defproject clj_manifest "0.2.0"
+(defproject clj_manifest "0.3.0-SNAPSHOT"
   :description "Reads the manifest file if running as ubjerjar"
   :url "https://github.com/benedekfazekas/clj_manifest.git"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]]
-  :repositories {"snapshots" {:url "http://10.251.76.32:8081/nexus/content/repositories/snapshots"
-                              :username "admin" :password "admin123"}
-                 "releases" {:url "http://10.251.76.32:8081/nexus/content/repositories/releases"
-                             :username "admin" :password "admin123" }
-                 "thirdparty" {:url "http://10.251.76.32:8081/nexus/content/repositories/thirdparty"}})
+  :profiles {:dev {:resource-paths ["dev-resources"]}}
+  :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/src/manifest/core.clj
+++ b/src/manifest/core.clj
@@ -1,15 +1,28 @@
 (ns manifest.core
   (:require [clojure.java.io :as io]
+            [clojure.string]
             [clojure.walk :as walk])
   (:import [java.util.jar Manifest]
            [java.net URL]))
 
 ;; Note that the manifest you want will only be on the classpath if it lives in the uberjar
 
+(defn- join-continuations [input]
+  (let [input (vec input)
+        continuation-indexes (keep-indexed #(when (= \space (first %2)) %1) input)
+        spliced (reduce (fn [v i]
+                          (update-in v [(dec i)] str
+                                     (clojure.string/replace-first (get v i) " " "")))
+                        input
+                        (reverse continuation-indexes))
+        continuation-indexes (set continuation-indexes)]
+    (keep-indexed (fn [i v] (when-not (continuation-indexes i) v)) spliced)))
+
 (defn- read-manifest [url]
   (->> url
        io/reader line-seq
        (remove empty?)
+       join-continuations
        (map #(clojure.string/split % #":\s*" 2))
        (into {})
        walk/keywordize-keys))

--- a/test/manifest/core_test.clj
+++ b/test/manifest/core_test.clj
@@ -1,0 +1,14 @@
+(ns manifest.core-test
+  (:require [clojure.test :refer [deftest run-tests is]]
+            [manifest.core :as manifest]))
+
+(def parsed-manifest {:Manifest-Version "1.0"
+                      :Release-Version "1.1.0-long-version-name-first-continuation-second-continuation"
+                      :Build-Timestamp "2016-09-20 16:42:23+0000"
+                      :Built-By "A Clojure Developer"
+                      :Created-By "Leiningen 2.6.1"
+                      :Build-Jdk "1.8.0_92"
+                      :Main-Class "clj_simple.app"})
+
+(deftest read-manifest
+  (is (= parsed-manifest (#'manifest/read-manifest "dev-resources/MANIFEST.MF"))))


### PR DESCRIPTION
I recently created a build that had a very long value in the manifest file - so much so that it split the long value adding a continuation onto the following line. See [`continuation` under the specification section here](http://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html#Name-Value_pairs_and_Sections)

This issue caused an exception in the `read-manifest` function. I've applied an update to fix this. The test uses `dev-resources/MANIFEST.MF` which contains continuations.