### PR TITLE
Ensure file is closed once it's been read

### DIFF
--- a/src/manifest/core.clj
+++ b/src/manifest/core.clj
@@ -19,13 +19,14 @@
     (keep-indexed (fn [i v] (when-not (continuation-indexes i) v)) spliced)))
 
 (defn- read-manifest [url]
-  (->> url
-       io/reader line-seq
-       (remove empty?)
-       join-continuations
-       (map #(clojure.string/split % #":\s*" 2))
-       (into {})
-       walk/keywordize-keys))
+  (with-open [r (io/reader url)]
+    (->> r
+         line-seq
+         (remove empty?)
+         join-continuations
+         (map #(clojure.string/split % #":\s*" 2))
+         (into {})
+         walk/keywordize-keys)))
 
 (defn manifest [main-class-name]
   (try


### PR DESCRIPTION
I noticed a native memory leak in one of our apps that was performing many reads from manifest.mf files via this library. It was due to the files not being closed, as such the data was being GC'd by the JVM (when there were no references to it) but retained in native memory.